### PR TITLE
updated info for UDM-Base

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Here are some known interfaces for Unifi gateways, for use in the rest of the gu
 - UXG Pro - eth0 (WAN1, RJ-45), eth2 (WAN2, SFP+)
 - UXG Max - eth4
 - UCG Ultra - eth4
-- UDR - eth4
+- UDR and UDM-Base (the egg) - eth4
 - UDM Pro or SE - eth8 (WAN1, RJ-45), eth9 (WAN2, SFP+)
 
 ### Prerequisites:


### PR DESCRIPTION
added eth4 for UDM Base 
https://store.ui.com/us/en/products/udm


some notes from personal experience when i updated to v4.0.6 from v3.0.6:

- did not need to clone the mac address since its included into the `wpa_suppliacant.conf`
- ran `wpa_supplicant -i eth4 -D wired -c /etc/wpa_supplicant/wpa_supplicant.conf` to bring up the auth for ATT

what `wpa_supplicant.conf` should look like:
```conf
# Generated by 802.1x Credential Extraction Tool
# Copyright (c) 2018-2019 devicelocksmith.com
# Version: 1.04 windows 386
# 
# Change file names to absolute paths
eapol_version=1
ap_scan=0
fast_reauth=1
network={
        ca_cert="/etc/wpa_supplicant/CA_******.pem"
        client_cert="/etc/wpa_supplicant/Client_******.pem"
        eap=TLS
        eapol_flags=0
        identity="**BGW ONT MAC ADDRESS**" # Internet (ONT) interface MAC address must match this value
        key_mgmt=IEEE8021X
        phase1="allow_canned_success=1"
        private_key="/etc/wpa_supplicant/PrivateKey_******.pem"
}
```
`identity` value comes from the ONT interface thats on the BGW. this can be accomplished using devicelocksmith's `mfg_dat_decode` tool after certs are extracted using something like [0x888e's script](https://github.com/0x888e/certs) or [iwleonards's extract-mfg](https://github.com/iwleonards/extract-mfg)

`mfg_dat-decode` is available on [devicelocksmith's site](https://www.devicelocksmith.com/2018/12/eap-tls-credentials-decoder-for-nvg-and.html)

